### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/near/near-gas-rs/compare/v0.3.0...v0.3.1) - 2025-07-18
+
+### Added
+
+- allowed to deserialize from u64 ([#19](https://github.com/near/near-gas-rs/pull/19))
+
+### Other
+
+- Use ubuntu-latest for CI runners instead of the deprecated ubuntu-20.04
+
 ## [0.3.0](https://github.com/near/near-gas-rs/compare/v0.2.5...v0.3.0) - 2024-08-12
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-gas"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [
     "Serhieiev Ivan <serhieievivan6@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-gas`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/near/near-gas-rs/compare/v0.3.0...v0.3.1) - 2025-07-18

### Added

- allowed to deserialize from u64 ([#19](https://github.com/near/near-gas-rs/pull/19))

### Other

- Use ubuntu-latest for CI runners instead of the deprecated ubuntu-20.04
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).