### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/near/near-gas-rs/compare/v0.3.4...v0.3.5) - 2026-04-07
+
+### Added
+
+- add 1PGas constant and parsing from str for PGas ([#32](https://github.com/near/near-gas-rs/pull/32))
+
+### Other
+
+- upgrade to Rust edition 2024 ([#29](https://github.com/near/near-gas-rs/pull/29))
+
 ## [0.3.4](https://github.com/near/near-gas-rs/compare/v0.3.3...v0.3.4) - 2026-01-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-gas"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 authors = [
     "Serhieiev Ivan <serhieievivan6@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-gas`: 0.3.4 -> 0.3.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/near/near-gas-rs/compare/v0.3.4...v0.3.5) - 2026-04-07

### Added

- add 1PGas constant and parsing from str for PGas ([#32](https://github.com/near/near-gas-rs/pull/32))

### Other

- upgrade to Rust edition 2024 ([#29](https://github.com/near/near-gas-rs/pull/29))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).