### PR TITLE
chore: release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/near/near-gas-rs/compare/v0.3.5...v0.3.6) - 2026-05-06
+
+### Added
+
+- arbitrary feature ([#33](https://github.com/near/near-gas-rs/pull/33))
+
 ## [0.3.5](https://github.com/near/near-gas-rs/compare/v0.3.4...v0.3.5) - 2026-04-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-gas"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 authors = [
     "Serhieiev Ivan <serhieievivan6@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-gas`: 0.3.5 -> 0.3.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.6](https://github.com/near/near-gas-rs/compare/v0.3.5...v0.3.6) - 2026-05-06

### Added

- arbitrary feature ([#33](https://github.com/near/near-gas-rs/pull/33))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).